### PR TITLE
Added hasRole() to v3 IACLManager

### DIFF
--- a/src/AaveV3.sol
+++ b/src/AaveV3.sol
@@ -8,11 +8,11 @@ import {IPool} from 'aave-v3-core/contracts/interfaces/IPool.sol';
 import {IPoolConfigurator} from 'aave-v3-core/contracts/interfaces/IPoolConfigurator.sol';
 import {IPriceOracleGetter} from 'aave-v3-core/contracts/interfaces/IPriceOracleGetter.sol';
 import {IAaveOracle} from 'aave-v3-core/contracts/interfaces/IAaveOracle.sol';
-import {IACLManager} from 'aave-v3-core/contracts/interfaces/IACLManager.sol';
+import {IACLManager as BasicIACLManager} from 'aave-v3-core/contracts/interfaces/IACLManager.sol';
 import {IPoolDataProvider} from 'aave-v3-core/contracts/interfaces/IPoolDataProvider.sol';
-import {IDefaultInterestRateStrategy} from "aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol";
-import {IReserveInterestRateStrategy} from "aave-v3-core/contracts/interfaces/IReserveInterestRateStrategy.sol";
-import {IDefaultInterestRateStrategy as IInterestRateStrategy} from "aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol";
+import {IDefaultInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol';
+import {IReserveInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IReserveInterestRateStrategy.sol';
+import {IDefaultInterestRateStrategy as IInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol';
 import {IPoolDataProvider as IAaveProtocolDataProvider} from 'aave-v3-core/contracts/interfaces/IPoolDataProvider.sol';
 
 /**
@@ -71,4 +71,8 @@ interface ICollector {
    * @param admin The address of the new funds administrator
    */
   function setFundsAdmin(address admin) external;
+}
+
+interface IACLManager is BasicIACLManager {
+  function hasRole(bytes32 role, address account) external view returns (bool);
 }

--- a/src/AaveV3.sol
+++ b/src/AaveV3.sol
@@ -75,4 +75,6 @@ interface ICollector {
 
 interface IACLManager is BasicIACLManager {
   function hasRole(bytes32 role, address account) external view returns (bool);
+
+  function DEFAULT_ADMIN_ROLE() external pure returns (bytes32);
 }


### PR DESCRIPTION
The "superadmin" (`DEFAULT_ADMIN_ROLE`) on the ACLManager of Aave v3 doesn't have a custom getter like `isPoolAdmin()`. To check for role ownership is necessary to use `hasRole()`, from the parent `AccessControl` contract.
Currently is not exposed on the contract imported from v3-core, so simpler to just import -> extend -> re-export transparently here on address book.

In addition, added a getter for `DEFAULT_ADMIN_ROLE`, as it is useful too.