### PR TITLE
Update AaveV3Ethereum.sol with DelegateAwareAToken

### DIFF
--- a/src/AaveV3Ethereum.sol
+++ b/src/AaveV3Ethereum.sol
@@ -30,6 +30,9 @@ library AaveV3Ethereum {
 
   address internal constant DEFAULT_INCENTIVES_CONTROLLER =
     0x8164Cc65827dcFe994AB23944CBC90e0aa80bFcb;
+    
+  address internal constant DELEGATE_AWARE_A_TOKEN_IMPL_REV_1 = 
+    0x21714092d90c7265f52fdfdae068ec11a23c6248;
 
   address internal constant DEFAULT_A_TOKEN_IMPL_REV_1 = 0x7EfFD7b47Bfd17e52fB7559d3f924201b9DbfF3d;
 


### PR DESCRIPTION
Etherscan: https://etherscan.io/address/0x21714092d90c7265f52fdfdae068ec11a23c6248#readContract

Deployment:

```
pragma solidity ^0.8.0;
import {WithChainIdValidation} from './WithChainIdValidation.sol';

import {DelegationAwareAToken} from 'aave-v3-core/contracts/protocol/tokenization/DelegationAwareAToken.sol';
import {IPool} from 'aave-v3-core/contracts/interfaces/IPool.sol';
import {IAaveIncentivesController} from 'aave-v3-core/contracts/interfaces/IAaveIncentivesController.sol';

contract DeployMainnetPayload is WithChainIdValidation {
  constructor() WithChainIdValidation(1) {}
}

contract DeployDelegationAwareToken is DeployMainnetPayload {
  function run() external {
    vm.startBroadcast();
    DelegationAwareAToken token = new DelegationAwareAToken(
      IPool(0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2)
    );
    token.initialize(
      IPool(0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2),
      address(0),
      address(0),
      IAaveIncentivesController(address(0)),
      0,
      'DELEGATE_AWARE_A_TOKEN',
      'DELEGATE_AWARE_A_TOKEN',
      ''
    );
    vm.stopBroadcast();
  }
}
```