### PR TITLE
fix: aggregator interface

### DIFF
--- a/src/AaveGovernanceV2.sol
+++ b/src/AaveGovernanceV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.0;
-pragma abicoder v2;
+pragma experimental ABIEncoderV2;
 
 interface IGovernanceStrategy {
   /**

--- a/src/AaveV2.sol
+++ b/src/AaveV2.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.6.0;
 pragma experimental ABIEncoderV2;
 
-import {AggregatorInterface} from 'aave-v3-core/contracts/dependencies/chainlink/AggregatorInterface.sol';
+import {AggregatorInterface} from './common/AggregatorInterface.sol';
 
 library DataTypes {
   // refer to the whitepaper, section 1.1 basic concepts for a formal description of these properties.

--- a/src/AaveV3.sol
+++ b/src/AaveV3.sol
@@ -13,7 +13,7 @@ import {IPoolDataProvider} from 'aave-v3-core/contracts/interfaces/IPoolDataProv
 import {IDefaultInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol';
 import {IReserveInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IReserveInterestRateStrategy.sol';
 import {IPoolDataProvider as IAaveProtocolDataProvider} from 'aave-v3-core/contracts/interfaces/IPoolDataProvider.sol';
-import {AggregatorInterface} from 'aave-v3-core/contracts/dependencies/chainlink/AggregatorInterface.sol';
+import {AggregatorInterface} from './common/AggregatorInterface.sol';
 
 interface IACLManager is BasicIACLManager {
   function hasRole(bytes32 role, address account) external view returns (bool);

--- a/src/AaveV3.sol
+++ b/src/AaveV3.sol
@@ -13,7 +13,7 @@ import {IPoolDataProvider} from 'aave-v3-core/contracts/interfaces/IPoolDataProv
 import {IDefaultInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IDefaultInterestRateStrategy.sol';
 import {IReserveInterestRateStrategy} from 'aave-v3-core/contracts/interfaces/IReserveInterestRateStrategy.sol';
 import {IPoolDataProvider as IAaveProtocolDataProvider} from 'aave-v3-core/contracts/interfaces/IPoolDataProvider.sol';
-import {AggregatorInterface} from './common/AggregatorInterface.sol';
+import {AggregatorInterface} from 'aave-v3-core/contracts/dependencies/chainlink/AggregatorInterface.sol';
 
 interface IACLManager is BasicIACLManager {
   function hasRole(bytes32 role, address account) external view returns (bool);

--- a/src/common/AggregatorInterface.sol
+++ b/src/common/AggregatorInterface.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0;
+
+interface AggregatorInterface {
+  function latestAnswer() external view returns (int256);
+
+  function latestTimestamp() external view returns (uint256);
+
+  function latestRound() external view returns (uint256);
+
+  function getAnswer(uint256 roundId) external view returns (int256);
+
+  function getTimestamp(uint256 roundId) external view returns (uint256);
+
+  event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt);
+
+  event NewRound(uint256 indexed roundId, address indexed startedBy, uint256 startedAt);
+}


### PR DESCRIPTION
- soften aggregator interface solidity version
- use `pragma experimental ABIEncoderV2` instead of `pragma abicoder v2` to fix compilation break on solidity version `0.6.0`