### PR TITLE
feat: Add V2 and V3 aToken Interfaces 

### DIFF
--- a/src/AaveV2.sol
+++ b/src/AaveV2.sol
@@ -942,3 +942,225 @@ interface IDefaultInterestRateStrategy {
 
   function variableRateSlope2() external view returns (uint256);
 }
+
+interface IATokenV2 {
+  /**
+   * @dev Emitted after the mint action
+   * @param from The address performing the mint
+   * @param value The amount being
+   * @param index The new liquidity index of the reserve
+   **/
+  event Mint(address indexed from, uint256 value, uint256 index);
+
+  /**
+   * @dev Emitted after aTokens are burned
+   * @param from The owner of the aTokens, getting them burned
+   * @param target The address that will receive the underlying
+   * @param value The amount being burned
+   * @param index The new liquidity index of the reserve
+   **/
+  event Burn(address indexed from, address indexed target, uint256 value, uint256 index);
+
+  /**
+   * @dev Emitted during the transfer action
+   * @param from The user whose tokens are being transferred
+   * @param to The recipient
+   * @param value The amount being transferred
+   * @param index The new liquidity index of the reserve
+   **/
+  event BalanceTransfer(address indexed from, address indexed to, uint256 value, uint256 index);
+
+  /**
+   * @dev Mints `amount` aTokens to `user`
+   * @param user The address receiving the minted tokens
+   * @param amount The amount of tokens getting minted
+   * @param index The new liquidity index of the reserve
+   * @return `true` if the the previous balance of the user was 0
+   */
+  function mint(address user, uint256 amount, uint256 index) external returns (bool);
+
+  /**
+   * @dev Burns aTokens from `user` and sends the equivalent amount of underlying to `receiverOfUnderlying`
+   * @param user The owner of the aTokens, getting them burned
+   * @param receiverOfUnderlying The address that will receive the underlying
+   * @param amount The amount being burned
+   * @param index The new liquidity index of the reserve
+   **/
+  function burn(address user, address receiverOfUnderlying, uint256 amount, uint256 index) external;
+
+  /**
+   * @dev Mints aTokens to the reserve treasury
+   * @param amount The amount of tokens getting minted
+   * @param index The new liquidity index of the reserve
+   */
+  function mintToTreasury(uint256 amount, uint256 index) external;
+
+  /**
+   * @dev Transfers aTokens in the event of a borrow being liquidated, in case the liquidators reclaims the aToken
+   * @param from The address getting liquidated, current owner of the aTokens
+   * @param to The recipient
+   * @param value The amount of tokens getting transferred
+   **/
+  function transferOnLiquidation(address from, address to, uint256 value) external;
+
+  /**
+   * @dev Transfers the underlying asset to `target`. Used by the LendingPool to transfer
+   * assets in borrow(), withdraw() and flashLoan()
+   * @param user The recipient of the underlying
+   * @param amount The amount getting transferred
+   * @return The amount transferred
+   **/
+  function transferUnderlyingTo(address user, uint256 amount) external returns (uint256);
+
+  /**
+   * @dev Invoked to execute actions on the aToken side after a repayment.
+   * @param user The user executing the repayment
+   * @param amount The amount getting repaid
+   **/
+  function handleRepayment(address user, uint256 amount) external;
+
+  /**
+   * @dev Returns the nonce of the given user.
+   * @param user The user to fetch the nonce for.
+   */
+  function _nonces(address user) external view returns (uint256);
+
+  /**
+   * @dev Returns the address of the incentives controller contract
+   **/
+  function getIncentivesController() external view returns (IAaveIncentivesController);
+
+  /**
+   * @dev Returns the address of the underlying asset of this aToken (E.g. WETH for aWETH)
+   **/
+  function UNDERLYING_ASSET_ADDRESS() external view returns (address);
+}
+
+interface IAaveIncentivesController {
+  event RewardsAccrued(address indexed user, uint256 amount);
+
+  event RewardsClaimed(address indexed user, address indexed to, uint256 amount);
+
+  event RewardsClaimed(
+    address indexed user,
+    address indexed to,
+    address indexed claimer,
+    uint256 amount
+  );
+
+  event ClaimerSet(address indexed user, address indexed claimer);
+
+  /*
+   * @dev Returns the configuration of the distribution for a certain asset
+   * @param asset The address of the reference asset of the distribution
+   * @return The asset index, the emission per second and the last updated timestamp
+   **/
+  function getAssetData(address asset) external view returns (uint256, uint256, uint256);
+
+  /*
+   * LEGACY **************************
+   * @dev Returns the configuration of the distribution for a certain asset
+   * @param asset The address of the reference asset of the distribution
+   * @return The asset index, the emission per second and the last updated timestamp
+   **/
+  function assets(address asset) external view returns (uint128, uint128, uint256);
+
+  /**
+   * @dev Whitelists an address to claim the rewards on behalf of another address
+   * @param user The address of the user
+   * @param claimer The address of the claimer
+   */
+  function setClaimer(address user, address claimer) external;
+
+  /**
+   * @dev Returns the whitelisted claimer for a certain address (0x0 if not set)
+   * @param user The address of the user
+   * @return The claimer address
+   */
+  function getClaimer(address user) external view returns (address);
+
+  /**
+   * @dev Configure assets for a certain rewards emission
+   * @param assets The assets to incentivize
+   * @param emissionsPerSecond The emission for each asset
+   */
+  function configureAssets(
+    address[] calldata assets,
+    uint256[] calldata emissionsPerSecond
+  ) external;
+
+  /**
+   * @dev Called by the corresponding asset on any update that affects the rewards distribution
+   * @param asset The address of the user
+   * @param userBalance The balance of the user of the asset in the lending pool
+   * @param totalSupply The total supply of the asset in the lending pool
+   **/
+  function handleAction(address asset, uint256 userBalance, uint256 totalSupply) external;
+
+  /**
+   * @dev Returns the total of rewards of an user, already accrued + not yet accrued
+   * @param user The address of the user
+   * @return The rewards
+   **/
+  function getRewardsBalance(
+    address[] calldata assets,
+    address user
+  ) external view returns (uint256);
+
+  /**
+   * @dev Claims reward for an user, on all the assets of the lending pool, accumulating the pending rewards
+   * @param amount Amount of rewards to claim
+   * @param to Address that will be receiving the rewards
+   * @return Rewards claimed
+   **/
+  function claimRewards(
+    address[] calldata assets,
+    uint256 amount,
+    address to
+  ) external returns (uint256);
+
+  /**
+   * @dev Claims reward for an user on behalf, on all the assets of the lending pool, accumulating the pending rewards. The caller must
+   * be whitelisted via "allowClaimOnBehalf" function by the RewardsAdmin role manager
+   * @param amount Amount of rewards to claim
+   * @param user Address to check and claim rewards
+   * @param to Address that will be receiving the rewards
+   * @return Rewards claimed
+   **/
+  function claimRewardsOnBehalf(
+    address[] calldata assets,
+    uint256 amount,
+    address user,
+    address to
+  ) external returns (uint256);
+
+  /**
+   * @dev returns the unclaimed rewards of the user
+   * @param user the address of the user
+   * @return the unclaimed user rewards
+   */
+  function getUserUnclaimedRewards(address user) external view returns (uint256);
+
+  /**
+   * @dev returns the unclaimed rewards of the user
+   * @param user the address of the user
+   * @param asset The asset to incentivize
+   * @return the user index for the asset
+   */
+  function getUserAssetData(address user, address asset) external view returns (uint256);
+
+  /**
+   * @dev for backward compatibility with previous implementation of the Incentives controller
+   */
+  function REWARD_TOKEN() external view returns (address);
+
+  /**
+   * @dev for backward compatibility with previous implementation of the Incentives controller
+   */
+  function PRECISION() external view returns (uint8);
+
+  /**
+   * @dev Gets the distribution end timestamp of the emissions
+   */
+  function DISTRIBUTION_END() external view returns (uint256);
+}

--- a/src/AaveV3.sol
+++ b/src/AaveV3.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.6.0;
 import {DataTypes} from 'aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol';
 import {ConfiguratorInputTypes} from 'aave-v3-core/contracts/protocol/libraries/types/ConfiguratorInputTypes.sol';
 import {IPoolAddressesProvider} from 'aave-v3-core/contracts/interfaces/IPoolAddressesProvider.sol';
+import {IAToken} from 'aave-v3-core/contracts/interfaces/IAToken.sol';
 import {IPool} from 'aave-v3-core/contracts/interfaces/IPool.sol';
 import {IPoolConfigurator} from 'aave-v3-core/contracts/interfaces/IPoolConfigurator.sol';
 import {IPriceOracleGetter} from 'aave-v3-core/contracts/interfaces/IPriceOracleGetter.sol';


### PR DESCRIPTION
This PR just adds the V2 and V3 aToken interfaces to their respective main contract files. V2 also now includes the IncentivesController interface since it's a return type from a v2 aToken function.

I also added the `_nonces(address user)` getter in the v2 interface since we just access nonces via a public `_nonces[..]` mapping in V2. 

Also named it `IATokenV2` to take away the burden of having to `import {IAToken as IATokenV2} from ...` in consumers.