### PR TITLE
ci(node): Use a common node version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          node-version-file: .nvmrc
           cache: "yarn"
 
       - name: install
@@ -55,8 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          node-version-file: .nvmrc
           cache: "yarn"
 
       - name: install

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -34,9 +34,9 @@ jobs:
         with:
           version: nightly
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
           cache: "yarn"
 
       - name: Install dependencies

--- a/.github/workflows/test-release-alpha.yml
+++ b/.github/workflows/test-release-alpha.yml
@@ -26,10 +26,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+          node-version-file: .nvmrc
           cache: "yarn"
 
       - name: Package size report

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,2 @@
+# https://vercel.com/docs/functions/runtimes/node-js/node-js-versions
+20


### PR DESCRIPTION
- and use the default npm registry everywhere.
- and use the current version of the setup-node action everywhere.
- and use the same node version for both projects