### PR TITLE
ci(deps): Enable dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,4 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,14 @@ updates:
      - "/ui/"
     schedule:
       interval: "weekly"
+
   - package-ecosystem: "gitsubmodule" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,10 +19,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # pin@v4
         with:
           node-version-file: .nvmrc
           cache: "yarn"
@@ -49,10 +49,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # pin@v4
         with:
           node-version-file: .nvmrc
           cache: "yarn"
@@ -62,7 +62,7 @@ jobs:
 
       - name: Cache Restore
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # pin@v4
         with:
           path: cache
           key: ${{ runner.os }}-verification-${{ hashFiles('safe.csv') }}-${{ github.sha }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Cache Save
         # if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # pin@v4
         with:
           path: cache
           key: ${{ runner.os }}-verification-${{ hashFiles('safe.csv') }}-${{ github.sha }}

--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -2,10 +2,10 @@ name: PR Comment
 
 on:
   workflow_run:
-    workflows: [Test]
+    workflows: [ Test ]
     types:
       - completed
 
 jobs:
   test:
-    uses: bgd-labs/github-workflows/.github/workflows/comment.yml@main
+    uses: bgd-labs/github-workflows/.github/workflows/comment.yml@130a99a60ad2c4944ab6114105d86fcbb841af77 # pin@main

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -14,6 +14,7 @@ on:
       - main
   workflow_dispatch:
 
+
 jobs:
   check-proposals:
     name: Check if library is up to date
@@ -24,17 +25,17 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@362aa1be8f31305295acb1032271acd5e9b99312 # pin@v1
         with:
           version: nightly
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # pin@v4
         with:
           node-version-file: .nvmrc
           cache: "yarn"
@@ -57,7 +58,7 @@ jobs:
           RPC_SCROLL: ${{ secrets.RPC_SCROLL }}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@00897e0bc2ceba9f86c9b0fda8429107112e6fa5
+        uses: peter-evans/create-pull-request@00897e0bc2ceba9f86c9b0fda8429107112e6fa5 # pin@00897e0bc2ceba9f86c9b0fda8429107112e6fa5
         with:
           author: Cache-bot <noreply@github.com>
           committer: Cache-bot <noreply@github.com>
@@ -68,7 +69,7 @@ jobs:
       - name: Post to a Slack channel
         id: slack
         if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # pin@v1.24.0
         with:
           # Slack channel id, channel name, or user id to post message.
           # See also: https://api.slack.com/methods/chat.postMessage#channels

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ permissions:
 name: release-please
 jobs:
   test-node:
-    uses: bgd-labs/github-workflows/.github/workflows/test-node.yml@main
+    uses: bgd-labs/github-workflows/.github/workflows/test-node.yml@130a99a60ad2c4944ab6114105d86fcbb841af77 # pin@main
     secrets: inherit
 
   release-please:
@@ -19,13 +19,13 @@ jobs:
     outputs:
       releaseCreated: ${{ steps.release.outputs.release_created }}
     steps:
-      - uses: googleapis/release-please-action@v4.1.3
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # pin@v4.1.3
         id: release
         with:
           release-type: node
 
   release-node:
-    uses: bgd-labs/github-workflows/.github/workflows/release-node.yml@main
+    uses: bgd-labs/github-workflows/.github/workflows/release-node.yml@130a99a60ad2c4944ab6114105d86fcbb841af77 # pin@main
     if: ${{ needs.release-please.outputs.releaseCreated }}
     needs: release-please
     secrets:

--- a/.github/workflows/test-release-alpha.yml
+++ b/.github/workflows/test-release-alpha.yml
@@ -7,12 +7,13 @@ concurrency:
 on:
   pull_request:
 
+
 jobs:
   test-solidity:
-    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@main
+    uses: bgd-labs/github-workflows/.github/workflows/foundry-test.yml@130a99a60ad2c4944ab6114105d86fcbb841af77 # pin@main
     secrets: inherit
   test-js:
-    uses: bgd-labs/github-workflows/.github/workflows/test-node.yml@main
+    uses: bgd-labs/github-workflows/.github/workflows/test-node.yml@130a99a60ad2c4944ab6114105d86fcbb841af77 # pin@main
     if: github.event.pull_request.head.repo.full_name == github.repository
     secrets: inherit
   pkg-size-report:
@@ -23,21 +24,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # pin@v4
         with:
           node-version-file: .nvmrc
           cache: "yarn"
 
       - name: Package size report
-        uses: pkg-size/action@v1
+        uses: pkg-size/action@a637fb0897b6f14f18e776d8c3dbccb34a1ad27b # pin@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release-node-alpha:
     if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
-    uses: bgd-labs/github-workflows/.github/workflows/release-node-alpha.yml@main
+    uses: bgd-labs/github-workflows/.github/workflows/release-node-alpha.yml@130a99a60ad2c4944ab6114105d86fcbb841af77 # pin@main
     needs:
       - test-solidity
       - test-js


### PR DESCRIPTION
There are lots of outdated github-actions, let's update them.

I don't see an option to enforce dependency pinning for github actions via Dependabot, only found this open issue about it: https://github.com/dependabot/dependabot-core/issues/7913

I would prefer them being pinned.