### PR TITLE
ci(setup-node): use new universal setup-node action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,14 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # pin@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # pin@v4
-        with:
-          node-version-file: .nvmrc
-          cache: "yarn"
-
-      - name: install
-        run: yarn install --frozen-lockfile
+      - uses: bgd-labs/github-workflows/.github/actions/setup-node@main
 
       - name: verify
         run: yarn check:sanity
@@ -42,14 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # pin@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # pin@v4
-        with:
-          node-version-file: .nvmrc
-          cache: "yarn"
-
-      - name: install
-        run: yarn install --frozen-lockfile
+      - uses: bgd-labs/github-workflows/.github/actions/setup-node@main
 
       - name: Cache Restore
         id: cache

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -34,13 +34,7 @@ jobs:
         with:
           version: nightly
 
-      - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # pin@v4
-        with:
-          node-version-file: .nvmrc
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - uses: bgd-labs/github-workflows/.github/actions/setup-node@main
 
       - name: Generate library
         run: yarn generate:addresses

--- a/.github/workflows/test-release-alpha.yml
+++ b/.github/workflows/test-release-alpha.yml
@@ -25,11 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # pin@v3
 
-      - name: Setup Node.js
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # pin@v4
-        with:
-          node-version-file: .nvmrc
-          cache: "yarn"
+      - uses: bgd-labs/github-workflows/.github/actions/setup-node@main
 
       - name: Package size report
         uses: pkg-size/action@a637fb0897b6f14f18e776d8c3dbccb34a1ad27b # pin@v1


### PR DESCRIPTION
not sure if it makes sense for `.github/workflows/test-release-alpha.yml` as it didn't install deps before. Was that on purpose?