### PR TITLE
fix: umbrella tokenlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "ui"
       ],
       "devDependencies": {
-        "@bgd-labs/react-web3-icons": "^1.15.0",
+        "@bgd-labs/react-web3-icons": "^1.30.0",
         "@bgd-labs/toolbox": "^0.0.15",
         "@types/node": "^22.4.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
@@ -65,10 +65,9 @@
       }
     },
     "node_modules/@bgd-labs/react-web3-icons": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@bgd-labs/react-web3-icons/-/react-web3-icons-1.28.0.tgz",
-      "integrity": "sha512-sxTSirFyh8LwnD4Nre7JtarOZSlVfIyS6ySwg4csMivkkQZJbMGzL5n0RLp/18X6T977PvhrUBV6GnA9cwXsXg==",
-      "license": "MIT",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@bgd-labs/react-web3-icons/-/react-web3-icons-1.30.0.tgz",
+      "integrity": "sha512-uR50xqOSbrxj7U2G4s9g3dyo+yP5nEzVaNyFxG4Ca9zqggVaf3AyZdefKAUd10afoQv4d5NBVcl6bKu3BIGsRQ==",
       "dependencies": {
         "@loadable/component": "5.16.4",
         "tailwind-merge": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "homepage": "https://github.com/bgd-labs/aave-address-book#readme",
   "devDependencies": {
-    "@bgd-labs/react-web3-icons": "^1.15.0",
+    "@bgd-labs/react-web3-icons": "^1.30.0",
     "@bgd-labs/toolbox": "^0.0.15",
     "@types/node": "^22.4.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",

--- a/scripts/generator/assetsLibraryGenerator.ts
+++ b/scripts/generator/assetsLibraryGenerator.ts
@@ -69,7 +69,7 @@ export function fixUmbrellaStakeSymbol(symbol: string, underlying: string) {
   return symbol
     .replace('stk', 'STK_')
     .replace('wa', 'WA_')
-    .replace(/(V\d+)/g, '_$1');
+    .replace(/([Vv]\d+)/g, (match) => '_' + match.toUpperCase());
 }
 
 export function generateAssetsLibrary(

--- a/scripts/generator/svgUtils.ts
+++ b/scripts/generator/svgUtils.ts
@@ -10,6 +10,7 @@ export enum VARIANT {
   STATA_TOKEN,
   STATIC_A_TOKEN,
   UMBRELLA_STAKE_TOKEN,
+  UMBRELLA_STAKE_STATA_TOKEN,
 }
 
 const VARIANT_TAGS: Record<VARIANT, AssetTag | undefined> = {
@@ -18,6 +19,7 @@ const VARIANT_TAGS: Record<VARIANT, AssetTag | undefined> = {
   [VARIANT.STATA_TOKEN]: 'stata',
   [VARIANT.STATIC_A_TOKEN]: 'stata',
   [VARIANT.UMBRELLA_STAKE_TOKEN]: 'stk',
+  [VARIANT.UMBRELLA_STAKE_STATA_TOKEN]: 'stkStata',
 };
 
 export async function getSymbolUri(symbol: string, variant: VARIANT): Promise<string | undefined> {
@@ -32,4 +34,9 @@ export async function getSymbolUri(symbol: string, variant: VARIANT): Promise<st
   } else {
     console.log('symbol not found', symbol, variant);
   }
+}
+
+export function getUmbrellaStkVariant(symbol: string): VARIANT {
+  return symbol.slice(3).startsWith('wa') ?
+    VARIANT.UMBRELLA_STAKE_STATA_TOKEN : VARIANT.UMBRELLA_STAKE_TOKEN;
 }

--- a/scripts/generator/utils.ts
+++ b/scripts/generator/utils.ts
@@ -1,4 +1,5 @@
-import {Client, Hex, getAddress, zeroAddress} from 'viem';
+import {Client, Hex, getAddress, getContract, zeroAddress} from 'viem';
+import {IERC20Detailed_ABI} from '../../src/ts/abis/IERC20Detailed';
 import {AddressInfo, Addresses} from '../configs/types';
 import {getStorageAt} from 'viem/actions';
 import {ChainList} from '@bgd-labs/toolbox';
@@ -143,4 +144,13 @@ export function removeNetworkAbbreviation(symbol: string): string {
   return symbol
     .replace('BasSep', '')
     .replace('Eth', '')
+}
+
+export async function getTokenSymbol(client: Client, token: Hex): Promise<string> {
+  const tokenContract = getContract({
+    address: token,
+    abi: IERC20Detailed_ABI,
+    client,
+  });
+  return await tokenContract.read.symbol();
 }


### PR DESCRIPTION
On web3-icons package we have two variants of umbrella stake: `stkStataToken` and `stkToken`. 
This PR fixes the generated tokenlist to correctly generate the icons in tokenlist for umbrella `stkStataToken` and `stkToken`.