### PR TITLE
chore: fix test after horizon collector upgrade

### DIFF
--- a/tests/cache/verified.json
+++ b/tests/cache/verified.json
@@ -4562,6 +4562,9 @@
     },
     "0x943827DCA022D0F354a8a8c332dA1e5Eb9f9F931": {
       "name": "TransparentUpgradeableProxy"
+    },
+    "0x9EB507147b99D3Cde32A53Bd5cd12bDEEaC26E5c": {
+      "name": "ATokenInstance"
     }
   },
   "10": {


### PR DESCRIPTION
ci fails after https://github.com/aave-dao/aave-address-book/pull/1360 which was triggered bc of [horizon collector upgrade](https://etherscan.io/tx/0xca9ab16ffc633b07fc420aa7170c5fbcca3105fce3d4fce88412b124a1ff96f6)