### PR TITLE
chore: fix verified tests

### DIFF
--- a/tests/cache/verified.json
+++ b/tests/cache/verified.json
@@ -4607,6 +4607,9 @@
     },
     "0x441E4053fDDF1e1a77a39d00309Af389096d4124": {
       "name": "GnosisSafeProxy"
+    },
+    "0x2DF6DfbD281F127a3690c87E4572076778a9EDa5": {
+      "name": "TransparentUpgradeableProxy"
     }
   },
   "10": {


### PR DESCRIPTION
latest auto refresh release fails bc of etherscan ci issue, this fixes verified.json so tests pass & release can go through

ref: https://github.com/aave-dao/aave-address-book/commit/19723607ecbf352ab374590c8b993f3e3dbca744