### PR TITLE
feat: publish versioned JSON API releases to S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,55 @@ jobs:
     uses: aave-dao/github-workflows/.github/workflows/release-node.yml@main
     needs: release-please
 
+  release-address-book-api:
+    if: ${{ needs.release-please.outputs.releaseCreated == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      STATICS_BUCKET: ${{ secrets.STATICS_BUCKET }}
+    needs:
+      - release-please
+      - release-node
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: aave-dao/github-workflows/.github/actions/setup-node@main
+
+      - name: Generate address book API
+        run: npm --workspace ui run generate:api
+
+      - name: Read release version
+        id: version
+        run: echo "value=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Publish versioned address book API
+        run: |
+          : "${STATICS_BUCKET:?STATICS_BUCKET must be configured}"
+          aws s3 sync ui/out/api/v1/ \
+            "s3://${STATICS_BUCKET}/address-book/releases/v${{ steps.version.outputs.value }}/" \
+            --delete \
+            --content-type "application/json" \
+            --cache-control "public,max-age=31536000,immutable" \
+            --only-show-errors
+
+      - name: Publish latest address book API
+        run: |
+          : "${STATICS_BUCKET:?STATICS_BUCKET must be configured}"
+          aws s3 sync ui/out/api/v1/ \
+            "s3://${STATICS_BUCKET}/address-book/releases/latest/" \
+            --delete \
+            --content-type "application/json" \
+            --cache-control "public,max-age=60,must-revalidate" \
+            --only-show-errors
+
   release-node-alpha:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     needs:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ QUICKNODE_TOKEN=your_quicknode_token
 The interactive UI can be found in [ui](./ui) package. The UI is a React application that is compiled as static build, so it can be hosted on github pages.
 You can fine an instance of the UI at [search.onaave.com](https://search.onaave.com/)
 
+## Address book API
+
+Each release is published as a static JSON document for programmatic consumption:
+
+```text
+https://assets.aave.com/address-book/releases/latest/manifest.json
+https://assets.aave.com/address-book/releases/latest/address-book.json
+https://assets.aave.com/address-book/releases/latest/modules/AaveV3Ethereum.json
+https://assets.aave.com/address-book/releases/v<version>/modules/AaveV3Ethereum.json
+```
+
+The API contains an aggregate address book, one file per package module, and a manifest containing
+the package version, commit, byte sizes, and SHA-256 hashes. The `latest` files have a short cache
+lifetime, while versioned files are immutable. The deployment bucket is configured through the
+`STATICS_BUCKET` GitHub Actions secret.
+
 ## Resources
 
 - **[Raycast Extension](https://www.raycast.com/smbdy/aave-search)** - Quick address lookup


### PR DESCRIPTION
## Summary

- reuse the canonical static JSON API generator introduced in #1512
- publish its manifest, aggregate, and per-module files to `assets.aave.com` on each release
- maintain immutable versioned paths and a short-lived `latest` path using GitHub OIDC credentials

## Published paths

- `address-book/releases/v<version>/`
- `address-book/releases/latest/`

## Validation

- `npx vitest run tests/jsonApi.spec.ts`
- `npm run build:ui`
- Prettier and workflow YAML validation
