### PR TITLE
feat: add static JSON address book API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@aave-dao/aave-address-book)](https://www.npmjs.com/package/@aave-dao/aave-address-book)
 
-An up-to-date registry of all Aave ecosystem smart contract addresses for use in Solidity and JavaScript/TypeScript projects.
+An up-to-date registry of all Aave ecosystem smart contract addresses for use in Solidity and JavaScript/TypeScript projects or usage via JSON API.
 
 🔍 **[Search addresses online](https://aave-dao.github.io/aave-address-book/)**
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ console.log(AaveV3Ethereum.POOL); // "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2
 console.log(AaveV3Ethereum.CHAIN_ID); // 1
 ```
 
+### JSON API
+
+The latest address book is also published as static JSON alongside the search UI:
+
+- [`manifest.json`](https://aave-dao.github.io/aave-address-book/api/v1/manifest.json) describes the deployed package version, source commit, aggregate, and available modules.
+- [`address-book.json`](https://aave-dao.github.io/aave-address-book/api/v1/address-book.json) contains every exported address-book module.
+- `modules/<name>.json` contains one module, for example [`modules/AaveV3Ethereum.json`](https://aave-dao.github.io/aave-address-book/api/v1/modules/AaveV3Ethereum.json).
+
+Manifest paths are relative to the manifest URL and module names are case-sensitive:
+
+```typescript
+const manifestUrl =
+  "https://aave-dao.github.io/aave-address-book/api/v1/manifest.json";
+const manifest = await fetch(manifestUrl).then((response) => response.json());
+const ethereum = manifest.modules.find(
+  (module: { name: string }) => module.name === "AaveV3Ethereum",
+);
+const addresses = await fetch(new URL(ethereum.path, manifestUrl)).then(
+  (response) => response.json(),
+);
+```
+
+The `/api/v1` URLs always represent the latest deployment from `main`. Use the manifest's `commit` and SHA-256 fields to identify and verify the exact content. A future breaking change to the JSON structure or paths will use a new API version.
+
 ## Development
 
 ### Generate addresses

--- a/scripts/generateJsonApi.ts
+++ b/scripts/generateJsonApi.ts
@@ -1,0 +1,199 @@
+import {createHash} from 'node:crypto';
+import {execFileSync} from 'node:child_process';
+import {mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {join, resolve} from 'node:path';
+import * as addressBook from '../src/ts/AaveAddressBook';
+
+export type JsonValue = null | boolean | number | string | JsonValue[] | {[key: string]: JsonValue};
+
+export type JsonApiFile = {
+  path: string;
+  bytes: number;
+  sha256: string;
+};
+
+export type JsonApiModule = JsonApiFile & {
+  name: string;
+  chainId: number;
+};
+
+export type JsonApiManifest = {
+  schemaVersion: 1;
+  packageVersion: string;
+  commit: string;
+  aggregate: JsonApiFile;
+  modules: JsonApiModule[];
+};
+
+type GenerateJsonApiOptions = {
+  outputDirectory?: string;
+  packageVersion?: string;
+  commit?: string;
+  source?: Record<string, unknown>;
+};
+
+const REPOSITORY_ROOT = resolve(__dirname, '..');
+const DEFAULT_OUTPUT_DIRECTORY = join(REPOSITORY_ROOT, 'ui', 'out', 'api', 'v1');
+const MODULE_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
+
+function normalizeJsonValue(value: unknown, path: string, ancestors: Set<object>): JsonValue {
+  if (value === null) return null;
+
+  if (typeof value === 'string' || typeof value === 'boolean') return value;
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(`Non-finite number at ${path}`);
+    }
+    return value;
+  }
+
+  if (typeof value !== 'object') {
+    throw new TypeError(`Unsupported JSON value at ${path}: ${typeof value}`);
+  }
+
+  if (ancestors.has(value)) {
+    throw new TypeError(`Circular JSON value at ${path}`);
+  }
+  ancestors.add(value);
+
+  if (Array.isArray(value)) {
+    const normalized = value.map((item, index) =>
+      normalizeJsonValue(item, `${path}[${index}]`, ancestors),
+    );
+    ancestors.delete(value);
+    return normalized;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError(`Non-plain object at ${path}`);
+  }
+
+  const normalized: {[key: string]: JsonValue} = {};
+  for (const key of Object.keys(value).sort()) {
+    normalized[key] = normalizeJsonValue(
+      (value as Record<string, unknown>)[key],
+      `${path}.${key}`,
+      ancestors,
+    );
+  }
+  ancestors.delete(value);
+  return normalized;
+}
+
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(normalizeJsonValue(value, '$', new Set()));
+}
+
+export function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function describeFile(path: string, contents: string): JsonApiFile {
+  return {
+    path,
+    bytes: Buffer.byteLength(contents, 'utf8'),
+    sha256: sha256(contents),
+  };
+}
+
+function readPackageVersion(): string {
+  const packageJson = JSON.parse(readFileSync(join(REPOSITORY_ROOT, 'package.json'), 'utf8')) as {
+    version?: unknown;
+  };
+
+  if (typeof packageJson.version !== 'string' || !packageJson.version) {
+    throw new Error('The root package.json does not contain a valid version');
+  }
+  return packageJson.version;
+}
+
+function resolveCommit(): string {
+  const commit =
+    process.env.GITHUB_SHA ??
+    execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: REPOSITORY_ROOT,
+      encoding: 'utf8',
+    }).trim();
+
+  if (!COMMIT_PATTERN.test(commit)) {
+    throw new Error(`Expected a full git commit SHA, received: ${commit}`);
+  }
+  return commit.toLowerCase();
+}
+
+export function generateJsonApi(options: GenerateJsonApiOptions = {}): JsonApiManifest {
+  const outputDirectory = resolve(options.outputDirectory ?? DEFAULT_OUTPUT_DIRECTORY);
+  const source = options.source ?? (addressBook as unknown as Record<string, unknown>);
+  const moduleNames = Object.keys(source).sort();
+
+  if (moduleNames.length === 0) {
+    throw new Error('The address book does not export any modules');
+  }
+
+  const aggregate: Record<string, JsonValue> = {};
+  const moduleContents = new Map<string, string>();
+  const modules: JsonApiModule[] = [];
+
+  for (const name of moduleNames) {
+    if (!MODULE_NAME_PATTERN.test(name)) {
+      throw new Error(`Invalid address-book module name: ${name}`);
+    }
+
+    const moduleValue = source[name];
+    const normalizedModule = normalizeJsonValue(moduleValue, `$.${name}`, new Set());
+
+    if (
+      normalizedModule === null ||
+      Array.isArray(normalizedModule) ||
+      typeof normalizedModule !== 'object'
+    ) {
+      throw new TypeError(`Address-book module ${name} must be an object`);
+    }
+
+    const chainId = normalizedModule.CHAIN_ID;
+    if (typeof chainId !== 'number' || !Number.isSafeInteger(chainId) || chainId <= 0) {
+      throw new TypeError(`Address-book module ${name} must have a positive integer CHAIN_ID`);
+    }
+
+    aggregate[name] = normalizedModule;
+    const contents = JSON.stringify(normalizedModule);
+    const path = `modules/${name}.json`;
+    moduleContents.set(name, contents);
+    modules.push({name, chainId, ...describeFile(path, contents)});
+  }
+
+  const aggregateContents = JSON.stringify(aggregate);
+  const manifest: JsonApiManifest = {
+    schemaVersion: 1,
+    packageVersion: options.packageVersion ?? readPackageVersion(),
+    commit: options.commit ?? resolveCommit(),
+    aggregate: describeFile('address-book.json', aggregateContents),
+    modules,
+  };
+
+  if (!COMMIT_PATTERN.test(manifest.commit)) {
+    throw new Error(`Expected a full git commit SHA, received: ${manifest.commit}`);
+  }
+
+  rmSync(outputDirectory, {recursive: true, force: true});
+  mkdirSync(join(outputDirectory, 'modules'), {recursive: true});
+  writeFileSync(join(outputDirectory, 'address-book.json'), aggregateContents, 'utf8');
+
+  for (const [name, contents] of moduleContents) {
+    writeFileSync(join(outputDirectory, 'modules', `${name}.json`), contents, 'utf8');
+  }
+
+  writeFileSync(join(outputDirectory, 'manifest.json'), stableStringify(manifest), 'utf8');
+
+  return manifest;
+}
+
+if (require.main === module) {
+  const manifest = generateJsonApi();
+  const totalBytes =
+    manifest.aggregate.bytes + manifest.modules.reduce((total, entry) => total + entry.bytes, 0);
+  console.log(`Generated ${manifest.modules.length} address-book modules (${totalBytes} bytes)`);
+}

--- a/tests/jsonApi.spec.ts
+++ b/tests/jsonApi.spec.ts
@@ -1,0 +1,93 @@
+import {existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+import {generateJsonApi, sha256, stableStringify} from 'scripts/generateJsonApi';
+import * as addressBook from 'src/ts/AaveAddressBook';
+
+const COMMIT = '0123456789abcdef0123456789abcdef01234567';
+const temporaryDirectories: string[] = [];
+
+function createTemporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'aave-address-book-api-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, {recursive: true, force: true});
+  }
+});
+
+describe('stableStringify', () => {
+  it('sorts object keys recursively while retaining array order', () => {
+    expect(stableStringify({z: {b: 2, a: 1}, a: [2, 1]})).toBe('{"a":[2,1],"z":{"a":1,"b":2}}');
+  });
+
+  it('rejects values that JSON.stringify would silently discard', () => {
+    expect(() => stableStringify({unsupported: undefined})).toThrow(
+      'Unsupported JSON value at $.unsupported: undefined',
+    );
+    expect(() => stableStringify({unsupported: 1n})).toThrow(
+      'Unsupported JSON value at $.unsupported: bigint',
+    );
+  });
+});
+
+describe('generateJsonApi', () => {
+  it('generates an aggregate, manifest, and exact file for every module', () => {
+    const outputDirectory = createTemporaryDirectory();
+    const staleModuleDirectory = join(outputDirectory, 'modules');
+    mkdirSync(staleModuleDirectory, {recursive: true});
+    writeFileSync(join(staleModuleDirectory, 'Stale.json'), '{}', 'utf8');
+
+    const manifest = generateJsonApi({
+      outputDirectory,
+      packageVersion: 'test-version',
+      commit: COMMIT,
+    });
+    const aggregateContents = readFileSync(join(outputDirectory, manifest.aggregate.path), 'utf8');
+    const aggregate = JSON.parse(aggregateContents) as Record<string, unknown>;
+    const moduleNames = Object.keys(addressBook).sort();
+
+    expect(manifest.schemaVersion).toBe(1);
+    expect(manifest.packageVersion).toBe('test-version');
+    expect(manifest.commit).toBe(COMMIT);
+    expect(manifest.modules.map(({name}) => name)).toEqual(moduleNames);
+    expect(Object.keys(aggregate)).toEqual(moduleNames);
+    expect(manifest.aggregate.bytes).toBe(Buffer.byteLength(aggregateContents, 'utf8'));
+    expect(manifest.aggregate.sha256).toBe(sha256(aggregateContents));
+    expect(existsSync(join(staleModuleDirectory, 'Stale.json'))).toBe(false);
+
+    for (const entry of manifest.modules) {
+      const contents = readFileSync(join(outputDirectory, entry.path), 'utf8');
+      const moduleValue = addressBook[entry.name as keyof typeof addressBook] as unknown;
+
+      expect(contents).toBe(stableStringify(moduleValue));
+      expect(JSON.parse(contents)).toEqual(aggregate[entry.name]);
+      expect(entry.chainId).toBe((moduleValue as {CHAIN_ID: number}).CHAIN_ID);
+      expect(entry.bytes).toBe(Buffer.byteLength(contents, 'utf8'));
+      expect(entry.sha256).toBe(sha256(contents));
+    }
+
+    const manifestOnDisk = JSON.parse(readFileSync(join(outputDirectory, 'manifest.json'), 'utf8'));
+    expect(manifestOnDisk).toEqual(manifest);
+  });
+
+  it('rejects modules without a valid CHAIN_ID before replacing output', () => {
+    const outputDirectory = createTemporaryDirectory();
+    const sentinel = join(outputDirectory, 'sentinel');
+    writeFileSync(sentinel, 'keep', 'utf8');
+
+    expect(() =>
+      generateJsonApi({
+        outputDirectory,
+        packageVersion: 'test-version',
+        commit: COMMIT,
+        source: {Invalid: {CHAIN_ID: 1.5}},
+      }),
+    ).toThrow('Address-book module Invalid must have a positive integer CHAIN_ID');
+    expect(readFileSync(sentinel, 'utf8')).toBe('keep');
+  });
+});

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "npm run generate:api",
+    "generate:api": "node --import tsx ../scripts/generateJsonApi.ts",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Adds a versioned static JSON API to the existing GitHub Pages build.

- Publishes a manifest, aggregate address book, and per-module JSON files
- Includes deterministic serialization, commit metadata, byte sizes, and SHA-256 hashes
- Adds generator tests and usage documentation

Tested with `npm test` and `npm run build:ui`.