### PR TITLE
fix: read API release version in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Read release version
         id: version
-        run: echo "value=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: node -e "console.log('value=' + require('./package.json').version)" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # pin@v5.1.1


### PR DESCRIPTION
## Summary

Fix the `Read release version` step in the address-book API release job. The escaped quotes were passed literally to Bash, causing a syntax error around `require(...)`.

The replacement writes the `value=<version>` output directly from Node without nested shell command substitution.

## Validation

- reproduced the failing command from [run 31182464542](https://github.com/aave-dao/aave-address-book/actions/runs/31182464542/job/92879495257)
- verified the corrected command writes `value=4.65.0` to `$GITHUB_OUTPUT`
- Prettier check passed
- workflow YAML parses successfully
